### PR TITLE
Updated version of diagonalise.py

### DIFF
--- a/diagonalise.py
+++ b/diagonalise.py
@@ -31,123 +31,478 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+import time
+import numba
+from numba.types import uint64
 import numpy as np
-import scipy.sparse
+import scipy.sparse # Sparse matrices
+import scipy.sparse.linalg # Diagonalisation routines
+import scipy.special # To compute binomial coefficients
+
+
+def random_input():
+    x = np.random.randint(0xFFFFFFFFFFFFFFFF, dtype=np.uint64)
+    i = np.random.randint(0, 64, dtype=np.uint64)
+    j = np.random.randint(i + 1, 65, dtype=np.uint64)
+    return (x, i, j)
+
+
+@numba.jit("u8(u8, u8, u8)", nopython=True)
+def _extract_part(x, i, j):
+    """
+    Masks out all the bits of ``x`` outside of ``[i, j)`` range. Indexing is from the
+    highest significant bit to the lowest significant one.
+
+    Example:
+
+    >>> '{:064b}'.format(_extract_part(0xFFFFFFFFFFFFFFFF, 20, 30))
+    '0000000000000000000011111111110000000000000000000000000000000000'
+    """
+    # Note the if else if important, because shifting by 64 results in a noop
+    # rather than producing 0.
+    a = (uint64(0xFFFFFFFFFFFFFFFF) >> i) if i < 64 else uint64(0)
+    b = uint64(0xFFFFFFFFFFFFFFFF) << (64 - j)
+    return x & a & b
+
+
+@numba.jit("u8(u8)", nopython=True)
+def _reverse_bits_u1(x):
+    """
+    Reverses the bits in a byte of data.
+
+    The algorithm is taken from
+    https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64Bits.
+    """
+    # return ((x * uint64(0x80200802)) & uint64(0x0884422110)) * uint64(0x0101010101) >> uint64(32)
+    return (
+        (
+            ((x & 0xFF) * uint64(0x0802) & uint64(0x22110))
+            | ((x & 0xFF) * uint64(0x8020) & uint64(0x88440))
+        )
+        * uint64(0x10101)
+        >> uint64(16)
+    ) & uint64(0xFF)
+
+
+@numba.jit("u8(u8)", nopython=True)
+def _reverse_bits_u8(x):
+    """
+    Reverses the bits in 8 bytes of data. We manually reverse the bytes and
+    rely on ``_reverse_bits_u1`` to reverse the bits in every byte.
+
+    **TODO**: The implementation is pretty bad, but I'm too lazy to do it
+    properly (twesterhout).
+    """
+    return (
+        (_reverse_bits_u1((x >> uint64(0)) & 0xFF) << uint64(56))
+        | (_reverse_bits_u1((x >> uint64(8)) & 0xFF) << uint64(48))
+        | (_reverse_bits_u1((x >> uint64(16)) & 0xFF) << uint64(40))
+        | (_reverse_bits_u1((x >> uint64(24)) & 0xFF) << uint64(32))
+        | (_reverse_bits_u1((x >> uint64(32)) & 0xFF) << uint64(24))
+        | (_reverse_bits_u1((x >> uint64(40)) & 0xFF) << uint64(16))
+        | (_reverse_bits_u1((x >> uint64(48)) & 0xFF) << uint64(8))
+        | (_reverse_bits_u1((x >> uint64(56)) & 0xFF) << uint64(0))
+    )
+
+
+@numba.jit("u8(u8, u8, u8)", nopython=True)
+def _reverse_bits_u8_part(x, i, j):
+    """
+    Reverses the bits of ``x[i:j]``.
+    """
+    a = _extract_part(x, 0, i) | _extract_part(x, j, 64)
+    b = _extract_part(_reverse_bits_u8(x), 64 - j, 64 - i)
+    if 64 - j > i:
+        b <<= 64 - j - i
+    else:
+        b >>= i + j - 64
+    return a | b
+
+
+@numba.jit("u8(u8, u8, u8, u8)", nopython=True)
+def _reverse(x, n, i, j):
+    """
+    64-bit integer ``x`` is treated as an array of ``n`` bits. Padding zeros
+    are added to the front (i.e. where the most significant bits are). This
+    function reverses the bits in ``x[i:j]``.
+    """
+    return _reverse_bits_u8_part(x, i + 64 - n, j + 64 - n)
+
+
+@numba.jit("u8(u8, u8, u8)", nopython=True)
+def _get_bit(x, n, i):
+    """
+    Returns the ``i``'th most significant bit of ``x``. ``n`` is the length of
+    ``x``.
+    """
+    return (x >> (n - 1 - i)) & 1
+
+
+@numba.jit("u8(u8, u8, u8, u8)", nopython=True)
+def _set_bit(x, n, i, b):
+    """
+    Sets the ``i``'th most significant bit of ``x`` to ``b``. ``n`` is the
+    length of ``x``.
+    """
+    return (x & ~(uint64(1) << (n - 1 - i))) | (uint64(b) << (n - 1 - i))
+
+
+@numba.jit("u8(u8, u8, u8)", nopython=True)
+def _flip_bit(x, n, i):
+    """
+    Flips the ``i``'th most significant bit of ``x``. ``n`` is the length of
+    ``x``.
+    """
+    return x ^ (uint64(1) << (n - 1 - i))
+
+
+@numba.jit("u8(u8, u8, u8, u8)", nopython=True)
+def _iter_swap(x, n, i, j):
+    """
+    Swaps the ``i``'th and ``j``'th most significant bits of ``x``. ``n`` is
+    the length of ``x``.
+    """
+    temp = _get_bit(x, n, i)
+    x = _set_bit(x, n, i, _get_bit(x, n, j))
+    x = _set_bit(x, n, j, temp)
+    return x
+
+
+@numba.jit("u8(u8, u8)", nopython=True)
+def next_permutation(x, n):
+    """
+    Returns the next permutation of bits in ``x``. If there are no more
+    permutations, 0 is returned.
+
+    See https://en.cppreference.com/w/cpp/algorithm/next_permutation for an
+    explanation.
+    """
+    if n < 2:
+        return 0
+    i = n - 1
+    while True:
+        i1 = i
+        i -= 1
+        if _get_bit(x, n, i) < _get_bit(x, n, i1):
+            i2 = n - 1
+            while not (_get_bit(x, n, i) < _get_bit(x, n, i2)):
+                i2 -= 1
+            x = _iter_swap(x, n, i, i2)
+            x = _reverse(x, n, i1, n)
+            return x
+        if i == 0:
+            return 0
+
+
+def sector(n, m):
+    """
+    Iterates over all spin configurations in a sector with given magnetisation.
+
+    :param n: Number of spins.
+    :param m: Magnetisation.
+    """
+    assert n > 0 and abs(m) < n and (n + m) % 2 == 0
+    number_ups = (n + m) // 2
+    s = int("0" * (n - number_ups) + "1" * number_ups, base=2)
+    while s != 0:
+        yield s
+        s = next_permutation(s, n)
+
+
+@numba.jit("u8(u8, u8, i8[:,:], f8[:], i8[:])", nopython=True)
+def fill_row(s, n, edges, coeffs, indices) -> int:
+    """
+    Fills the row of the Hamiltonian matrix corresponding to the basis vector
+    ``s``. ``n`` is total number of spins. ``edges`` is a 2D array of shape ?x2
+    representing the adjacency list of the lattice. Column indices of non-zero
+    elements are stored into ``indices`` array and the corresponding matrix
+    elements -- into ``coeffs``. The total number of non-zero elements in the
+    row is returned.
+    """
+    i = 0
+    c = 0.0
+    for k in range(edges.shape[0]):
+        edge = edges[k]
+        aligned = _get_bit(s, n, edge[0]) == _get_bit(s, n, edge[1])
+        c += -1.0 + 2.0 * int(aligned)
+        if not aligned:
+            coeffs[i] = 2.0
+            indices[i] = _flip_bit(_flip_bit(s, n, edge[0]), n, edge[1])
+            i += 1
+    if c != 0.0:
+        coeffs[i] = c
+        indices[i] = s
+        i += 1
+    return i
+
+
+def deduce_number_of_spins(edges):
+    """
+    Given graph edges, tries to deduce the number of spins in the system.
+    """
+    smallest = min(map(min, edges))
+    largest = max(map(max, edges))
+    if smallest != 0:
+        ValueError(
+            "Failed to deduce the number of spins: counting from 0, but the minimal index present is {}.".format(
+                smallest
+            )
+        )
+    return largest + 1
 
 
 class _Hamiltonian(object):
-    def __init__(self, matrix, g_to_l, l_to_g):
+    def __init__(self, n, matrix, l_to_g):
+        self.n = n
         self.matrix = matrix
-        self.g_to_l = g_to_l
+        # self.g_to_l = g_to_l
         self.l_to_g = l_to_g
 
 
-def get_entries(n, edges):
+@numba.jit("u8(u8[:,:], u8)", nopython=True)
+def _binary_search(xs, y):
+    first = 0
+    last = len(xs)
+    i = (last + first) // 2
+    while True:
+        if y > xs[i, 0]:
+            assert last - first > 1
+            first = i
+            i = (last + first) // 2
+        elif y < xs[i, 0]:
+            assert last - first > 1
+            last = i
+            i = (last + first) // 2
+        else:
+            return xs[i, 1]
+
+
+def make_hamiltonian(edges, number_of_spins=None):
     """
-    :param n:     Number of spins.
-    :param edges: Edges of the graph.
+    Returns the Heisenberg Hamiltonian on the lattice defined by the adjacency
+    list edges.
     """
-    empty_value = 2 ** 63 - 1
-    m = n % 2
-    number_ups = (n + m) // 2
+    n = (
+        number_of_spins
+        if number_of_spins is not None
+        else deduce_number_of_spins(edges)
+    )
+    edges = np.array(edges)
+    # List of all spins within a sector with a certain magnetisation
+    magnetisation = n % 2
+    number_ups = (n + magnetisation) // 2
+    shift = number_ups * (number_ups - 1) // 2 if number_ups > 0 else 0
+    all_spins = np.fromiter(
+        sector(n, magnetisation),
+        dtype=np.uint64,
+        count=int(scipy.special.comb(n, number_ups)),
+    )
 
-    def get_bit(x: int, i: int) -> int:
-        """
-        Returns the ``i``'th most significant bit.
+    # if 2 ** n > 134217728:
+    #     g_to_l = dict(((s, i) for i, s in enumerate(all_spins)))
+    # else:
+    #     g_to_l = np.empty(2**n, dtype=np.int64)
+    #     g_to_l[:] = 2**63 - 1
+    #     for i, s in enumerate(all_spins):
+    #         g_to_l[s] = i
+    global_to_local = np.empty((len(all_spins), 2), dtype=np.uint64)
+    for i, s in enumerate(all_spins):
+        global_to_local[i, 0] = s
+        global_to_local[i, 1] = i
 
-        :param x: Our spin configuration interpreted as an ``int``.
-        :param i: Index of the spin.
-        """
-        return (x >> (n - 1 - i)) & 1
-
-    def get_flipped(x: int, i: int, j: int) -> int:
-        """
-        Returns the spin configuration with ``i``'th and ``j``'th spins
-        **flipped** (not swapped).
-
-        :param x: Original spin configuration.
-        :param i: Index of the spin to flip.
-        :param j: Index of another spin to flip.
-        """
-        x ^= 1 << (n - 1 - i)
-        x ^= 1 << (n - 1 - j)
-        return x
-
-    def get_row(i: int):
-        """
-        Returns the sparse representation of the ``i``'th row of the
-        Hamiltonian. The row is a list of pairs (cⱼ, j), where cⱼ's are the matrix
-        elements ⟨i|H|j⟩'s.
-        """
-        c = 0.0
-        for J, edge in edges:
-
-            aligned = get_bit(i, edge[0]) == get_bit(i, edge[1])
-            c += J * (-1.0 + 2.0 * int(aligned))
-            if not aligned:
-                yield (2.0, get_flipped(i, *edge))
-        if c != 0.0:
-            yield (c, i)
-
-    g_to_l = np.empty(2 ** n, dtype=np.int64)
-    g_to_l[:] = empty_value
-    l_to_g = []
-    entries = []
-    k = 0
-    for i in range(2 ** n):
-        if bin(i).count("1") == number_ups:
-            g_to_l[i] = k
-            l_to_g.append(i)
-            k += 1
-            for (c, j) in get_row(i):
-                entries.append((c, i, j))
-
-    def matrix_from_entries():
-        data = np.fromiter(
-            (c for (c, _, _) in entries), dtype=np.float64, count=len(entries)
+    size_step = 65536000
+    size = min(size_step, len(all_spins) * (len(edges) + 1))
+    data = np.empty(size, dtype=np.float64)
+    row_ind = np.empty(size, dtype=np.int64)
+    col_ind = np.empty(size, dtype=np.int64)
+    coeffs = np.empty(len(edges) + 1, dtype=np.float64)
+    indices = np.empty(len(edges) + 1, dtype=np.int64)
+    count = 0
+    for s in all_spins:
+        k = fill_row(s, n, edges, coeffs, indices)
+        if count + k > size:
+            size += size_step
+            data = np.resize(data, size)
+            row_ind = np.resize(row_ind, size)
+            col_ind = np.resize(col_ind, size)
+        data[count : count + k] = coeffs[:k]
+        row_ind[count : count + k] = _binary_search(global_to_local, s)
+        col_ind[count : count + k] = np.fromiter(
+            (_binary_search(global_to_local, i) for i in indices[:k]),
+            dtype=np.int64,
+            count=k,
         )
-        row_ind = np.fromiter(
-            (g_to_l[i] for (_, i, _) in entries), dtype=np.int64, count=len(entries)
+        # row_ind[count:count + k] = g_to_l[s]
+        # col_ind[count:count + k] = np.fromiter((g_to_l[i] for i in indices[:k]), dtype=np.int64, count=k)
+        count += k
+    data = data[:count]
+    row_ind = row_ind[:count]
+    col_ind = col_ind[:count]
+    matrix = scipy.sparse.csr_matrix(
+        (data, (row_ind, col_ind)), shape=(len(all_spins), len(all_spins))
+    )
+    return _Hamiltonian(n, matrix, all_spins)
+
+
+def make_j1j2_hamiltonian(n, j2, edges_j1, edges_j2):
+    """
+    Constructs the Hamiltonian for a J1-J2 model.
+
+    :param n:  Number of spins in the system.
+    :param j2: ``J2/J1``.
+    :edges_j1: Adjacency list of the graph with coupling J1.
+    :edges_j2: Adjacency list of the graph with coupling J2.
+
+    **TODO**: Implementation could be optimised if the second part of the
+    Hamiltonian construction used l_to_g from the first one.
+    """
+    H = make_hamiltonian(edges_j1)
+    H_j2 = make_hamiltonian(edges_j2)
+    H_j2.matrix *= j2
+    H.matrix += H_j2.matrix
+    return H
+
+
+def make_j1j2_graph(L_x, L_y):
+    """
+    Returns adjacency lists of a J1-J2 model on a square lattice with given
+    size. Periodic boundary conditions are used.
+    """
+
+    def coord2index(x, y):
+        return x + y * L_x
+
+    def left(x, y):
+        return (x - 1 if x > 0 else L_x - 1, y)
+
+    def right(x, y):
+        return (x + 1 if x < L_x - 1 else 0, y)
+
+    def down(x, y):
+        return (x, y - 1 if y > 0 else L_y - 1)
+
+    def up(x, y):
+        return (x, y + 1 if y < L_y - 1 else 0)
+
+    def nearest_neighbours(p):
+        site = coord2index(*p)
+        return filter(
+            lambda t: t[0] < t[1],
+            map(
+                lambda t: (site, coord2index(*t)),
+                [left(*p), right(*p), down(*p), up(*p)],
+            ),
         )
-        col_ind = np.fromiter(
-            (g_to_l[j] for (_, _, j) in entries), dtype=np.int64, count=len(entries)
+
+    def next_nearest_neighbours(p):
+        site = coord2index(*p)
+        return filter(
+            lambda t: t[0] < t[1],
+            map(
+                lambda t: (site, coord2index(*t)),
+                [up(*left(*p)), down(*left(*p)), up(*right(*p)), down(*right(*p))],
+            ),
         )
-        assert not np.any(row_ind == empty_value)
-        assert not np.any(col_ind == empty_value)
-        return scipy.sparse.csr_matrix(
-            (data, (row_ind, col_ind)), shape=(len(l_to_g), len(l_to_g))
-        )
 
-    return _Hamiltonian(matrix_from_entries(), g_to_l, np.array(l_to_g))
+    edges_j1 = []
+    edges_j2 = []
+    for i in range(L_x):
+        for j in range(L_y):
+            for edge in nearest_neighbours((i, j)):
+                edges_j1.append(edge)
+            for edge in next_nearest_neighbours((i, j)):
+                edges_j2.append(edge)
+    return edges_j1, edges_j2
 
 
-def J1J2_Heisenberg(J2 = 0.0, nx = 5, ny = 5):
-    edges = []
-    for x in range(nx):
-        for y in range(ny):
-            edges.append((1.0, (x * ny + y, ((x + 1) % nx) * ny + (y) % ny)))
-            edges.append((1.0, (x * ny + y, ((x) % nx) * ny + (y + 1) % ny)))
-            edges.append((J2, (x * ny + y, ((x + 1) % nx) * ny + (y + 1) % ny)))
-            edges.append((J2, (x * ny + y, ((x - 1) % nx) * ny + (y + 1) % ny)))
-    return edges
+_CHAIN_4 = [(0, 1), (1, 2), (2, 3), (3, 0)]
+_CHAIN_5 = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
+_KAGOME_12 = [
+    (0, 1),
+    (0, 2),
+    (0, 4),
+    (0, 8),
+    (1, 2),
+    (1, 3),
+    (1, 11),
+    (2, 6),
+    (2, 10),
+    (3, 4),
+    (3, 5),
+    (3, 11),
+    (4, 5),
+    (4, 8),
+    (5, 7),
+    (5, 9),
+    (6, 7),
+    (6, 8),
+    (6, 10),
+    (7, 8),
+    (7, 9),
+    (9, 10),
+    (9, 11),
+    (10, 11),
+]
 
-edges = J1J2_Heisenberg(J2 = 0.0, nx = 5, ny = 5)
+_KAGOME_18 = [
+    (0, 1),
+    (0, 2),
+    (0, 4),
+    (0, 14),
+    (1, 2),
+    (1, 3),
+    (1, 17),
+    (2, 6),
+    (2, 10),
+    (3, 4),
+    (3, 5),
+    (3, 17),
+    (4, 5),
+    (4, 14),
+    (5, 7),
+    (5, 9),
+    (6, 7),
+    (6, 8),
+    (6, 10),
+    (7, 8),
+    (7, 9),
+    (8, 12),
+    (8, 16),
+    (9, 10),
+    (9, 11),
+    (10, 11),
+    (11, 13),
+    (11, 15),
+    (12, 13),
+    (12, 14),
+    (12, 16),
+    (13, 14),
+    (13, 15),
+    (15, 16),
+    (15, 17),
+    (16, 17),
+]
 
-nvectors = 1
-j1j2_25_H_sparse = get_entries(25, edges)
 
-from scipy.sparse.linalg import eigsh
-values, vectors = eigsh(j1j2_25_H_sparse.matrix, k = nvectors, which = 'SA')
+def diagonalise(H, output, nvectors=1):
+    """
+    Diagonalises the Hamiltonian ``H``. Results are save to the directory ``output``.
+    """
+    values, vectors = scipy.sparse.linalg.eigsh(H.matrix, k=nvectors, which="SA")
+    # Rounding so that we can detect degeneracy
+    rounded_values = (values * 1e5).astype(np.int64) / 1e5
+    values_unique = np.unique(rounded_values)
 
-values = (values * 1e+5).astype(np.int64) / 1e+5
-values_unique = np.sort(np.unique(values))
-
-val = values[0]
-vec = vectors[:, 0]
-f = open('./vectors/j1j2_0.0.txt', 'w')
-
-for ampl, global_index in zip(vec, j1j2_25_H_sparse.l_to_g):
-    f.write("{0:{fill}25b}".format(global_index, fill='0') + '\t' + "{:.10E}".format(ampl) + '\t0.0\n')
-
-f.flush()
-f.close()
+    if not os.path.exists(output):
+        os.mkdir(output)
+    with open("{}/values.txt".format(output), "w") as f:
+        for value in values:
+            f.write("{:.10E}\n".format(value))
+    for idx, (value, vector) in enumerate(zip(rounded_values, vectors.T)):
+        ([idx_unique],) = np.where(value == values_unique)
+        with open("{}/vector_{}_{}.txt".format(output, idx, idx_unique), "w") as f:
+            for σ, ψ in zip(H.l_to_g, vector):
+                f.write(
+                    "{sigma:0{n}b}\t{psi:.10E}\t0.0\n".format(sigma=σ, n=H.n, psi=ψ)
+                )


### PR DESCRIPTION
Hey @nikita-astronaut, here's a slightly better version of diagonalise.py script Andrey and I have been using the last couple of days. As a test, I just tried diagonalising 5x5 J1-J2 model with J2/J1=0.55. It took less than 20 minutes (both the construction of the Hamiltonian and the diagonalisation) and topped at around 10GB RAM usage.

Intended usage of the script is more or less the following:
```python
>>> import diagonalise
>>> H = diagonalise.make_j1j2_hamiltonian(16, 0.55, *diagonalise.make_j1j2_graph(4, 4))
>>> diagonalise.diagonalise(H, "4x4.exact", 5)
```
This will diagonalise J1-J2 model on a 4x4 square lattice and save the first 5 eigenvectors to "4x4.exact/" directory.

Ignore all the fancy bit manipulations. Important functions are `make_hamiltonian`, `make_j1j2_hamiltonian`, `make_j1j2_graph`, and `diagonalise`. You'll probably want to modify `make_j1j2_hamiltonian` a bit to accomodate the construction of loads of Hamiltonians with different J2s. I was planning to implement it myself, but I'm afraid I won't be able to do it right away...